### PR TITLE
Disable the PHP garbage collector

### DIFF
--- a/php/custom.ini
+++ b/php/custom.ini
@@ -6,6 +6,7 @@ short_open_tag = 0
 SMTP = "maildev"
 smtp_port = 25
 upload_max_filesize = "100M"
+zend.enable_gc = 0
 
 [date]
 date.timezone = "Europe/Paris"


### PR DESCRIPTION
Based on a Blackfire recommendation. 😉 
That change allows a **10% decrease of the execution time** and a **15% decrease of the I/O wait**.