### PR TITLE
Fix PHP crash during environment restart

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -46,7 +46,8 @@ RUN \
 
 # Install Xdebug
 RUN pecl install xdebug && \
-    docker-php-ext-enable xdebug
+    docker-php-ext-enable xdebug && \
+    mv "${PHP_INI_DIR}"/conf.d/docker-php-ext-xdebug.ini /home/xdebug.ini
 
 # Install Composer globally
 RUN curl -sS https://getcomposer.org/installer | php && \

--- a/php/entrypoint.sh
+++ b/php/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cat << CONFIG > "${PHP_INI_DIR}"/conf.d/blackfire.ini
+cat << CONFIG > /home/blackfire.ini
 extension=blackfire.so
 blackfire.agent_socket=tcp://blackfire:${BLACKFIRE_PORT}
 blackfire.agent_timeout=5
@@ -10,8 +10,5 @@ blackfire.log_level=${BLACKFIRE_LOG_LEVEL}
 blackfire.server_id=${BLACKFIRE_SERVER_ID}
 blackfire.server_token=${BLACKFIRE_SERVER_TOKEN}
 CONFIG
-
-mv "${PHP_INI_DIR}"/conf.d/blackfire.ini /home/blackfire.ini
-mv "${PHP_INI_DIR}"/conf.d/docker-php-ext-xdebug.ini /home/xdebug.ini
 
 exec "php-fpm"


### PR DESCRIPTION
There was an issue during the environment restart with Docker Compose as the Xdebug configuration file was already moved when the container has started for the first time.