### PR TITLE
Avoid duplicate sessions by reusing existing sessions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
               wget -qO- "https://github.com/havoc-io/mutagen/releases/download/$MUTAGEN_ARCHIVE" | tar xvz -C "$HOME/bin/"
               mutagen daemon start
           environment:
-            MUTAGEN_ARCHIVE: v0.8.0/mutagen_linux_amd64_v0.8.0.tar.gz
+            MUTAGEN_ARCHIVE: v0.9.0/mutagen_linux_amd64_v0.9.0.tar.gz
       - run:
           name: Create a Magento Open Source project
           command: |


### PR DESCRIPTION
Thanks to the latest Mutagen beta, it's now possible to add labels on sessions. Allowing us to easily reuse the existing session rather than creating a new session at each start.

https://github.com/havoc-io/mutagen/releases/tag/v0.9.0-beta2