### PR TITLE
N/A: Add sockets extension for magento/magento-cloud-components dependency

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -38,6 +38,7 @@ RUN \
         opcache \
         pdo_mysql \
         soap \
+        sockets \
         xsl \
         zip && \
     yes "" | pecl install apcu redis && \


### PR DESCRIPTION
Required for installing magento/magento-cloud-components via composer