### PR TITLE
Lowercase the compose name to match with other containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL := /bin/bash
 PHP_SERVICE := docker-compose exec php sh -c
 
 # Define a dynamic project name that will be prepended to each service name
-export COMPOSE_PROJECT_NAME := magento2_$(shell echo $${PWD\#\#*/})
+export COMPOSE_PROJECT_NAME := magento2_$(shell echo $${PWD\#\#*/} | tr '[:upper:]' '[:lower:]')
 
 # Extract environment variables needed by the environment
 export PROJECT_LOCATION := $(shell echo ${MAKEFILE_DIRECTORY})


### PR DESCRIPTION
In the case of a directory named "MyProject", we have the following behaviour:
Before:
<img width="803" alt="Capture d’écran 2019-10-01 à 00 28 02" src="https://user-images.githubusercontent.com/17000257/65922008-2f78b800-e3e4-11e9-8f28-94b09b46b5dd.png">

After:
<img width="805" alt="Capture d’écran 2019-10-01 à 00 39 00" src="https://user-images.githubusercontent.com/17000257/65922009-2f78b800-e3e4-11e9-92bf-f9d1aedb5d3b.png">
