### PR TITLE
Solve errors with composer cache not accessible

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,8 @@ services:
       - ./php/conf.d/custom.ini:/usr/local/etc/php/conf.d/custom.ini:ro
       # SSH socket
       - /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock
+      # Composer cache
+      - ${COMPOSER_CACHE_DIR:-~/Library/Caches/composer}:/.composer/cache
     tty: true
 
   redis:


### PR DESCRIPTION
Fixing this kind of issue:
```
fatal: could not create leading directories of '/var/www/.composer/cache/vcs/git-bitbucket.org-myrepository.git'
```