### PR TITLE
Update filesystem dependency version so we can use recent magento version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: "Build containers"
         run: |
           export $(cat .env.dist | sed 's/#.*//g' | xargs)
-          docker-compose up -d
+          docker compose up -d
         env:
           COMPOSE_PROJECT_NAME: magento
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "symfony/filesystem": "^3.0 || ^4.0 || ^5.0"
+        "symfony/filesystem": "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
     },
     "bin": [
         "bin/docker-local-install"


### PR DESCRIPTION
When we try to setup a clean project with following command line:
`composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition=2.4.6-p7 . --ignore-platform-reqs`

Then the one to install this dependency fails (it doesn't if we force it to take my branch):
`composer require --dev emakinafr/docker-magento2:"dev-bugfix/filesystem" --ignore-platform-reqs`

This is due to last filesystem versions not taken into account here.